### PR TITLE
Add GitHub Actions workflow for CI/CD and Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,101 @@
+name: C++ CI/CD with Release
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'thirdparty/**'
+      - 'CMakeLists.txt'
+  workflow_dispatch:
+
+env:
+  PROJECT_NAME: jcrud
+  BUILD_DIR: build
+
+jobs:
+  build_and_package:
+    name: Build and Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y             libboost-dev             libboost-filesystem-dev             libboost-iostreams-dev             libboost-thread-dev             libfmt-dev             libsqlite3-dev             libcrypto++-dev 
+            # Assuming ftxui, jmixin, jinject, expected, SQLiteCpp are handled by thirdparty/CMakeLists.txt or are header-only
+
+      - name: Configure CMake
+        run: cmake -B ${{ env.BUILD_DIR }} -S . -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build Project
+        run: cmake --build ${{ env.BUILD_DIR }} --config Release --parallel $(nproc)
+
+      - name: Create Archive
+        # The executable is expected to be in ${{ env.BUILD_DIR }}/<PROJECT_NAME> (e.g., build/jcrud)
+        # If src/CMakeLists.txt puts it in a subdirectory of BUILD_DIR (e.g. build/src/jcrud), this will need adjustment
+        # For now, assume it's directly in BUILD_DIR
+        run: |
+          EXECUTABLE_PATH="${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}"
+          if [ ! -f "$EXECUTABLE_PATH" ]; then
+            echo "Executable not found at $EXECUTABLE_PATH, checking common alternative paths..."
+            ALTERNATIVE_PATH_1="${{ env.BUILD_DIR }}/src/${{ env.PROJECT_NAME }}" # e.g. build/src/jcrud
+            if [ -f "$ALTERNATIVE_PATH_1" ]; then
+              EXECUTABLE_PATH="$ALTERNATIVE_PATH_1"
+            else
+              echo "Executable not found at $ALTERNATIVE_PATH_1 either."
+              echo "Listing contents of ${{ env.BUILD_DIR }} and ${{ env.BUILD_DIR }}/src (if exists) for debugging:"
+              ls -R "${{ env.BUILD_DIR }}"
+              exit 1
+            fi
+          fi
+          echo "Found executable at $EXECUTABLE_PATH"
+          tar czvf ${{ env.PROJECT_NAME }}-${{ github.sha }}.tar.gz -C "$(dirname "$EXECUTABLE_PATH")" "$(basename "$EXECUTABLE_PATH")"
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PROJECT_NAME }}-artifact-${{ github.sha }}
+          path: ${{ env.PROJECT_NAME }}-${{ github.sha }}.tar.gz
+
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: build_and_package
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write # Required to create a release and tags
+    steps:
+      - name: Checkout Code (for fetching tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetches all history for all tags and branches
+
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.PROJECT_NAME }}-artifact-${{ github.sha }}
+          # No path specified, defaults to current directory
+
+      - name: Generate Tag Name
+        id: generate_tag
+        run: |
+          TAG_NAME="release-$(date +'%Y%m%d')-${{ github.run_number }}"
+          echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.generate_tag.outputs.TAG_NAME }}
+          release_name: "Release ${{ steps.generate_tag.outputs.TAG_NAME }}"
+          body: |
+            Automated release for commit ${{ github.sha }}.
+            Triggered by: ${{ github.event_name }}
+            Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          files: ${{ env.PROJECT_NAME }}-${{ github.sha }}.tar.gz # This is the artifact downloaded in the previous step
+          # draft: false # Set to true if you want to manually publish later
+          # prerelease: false # Set to true if this is a pre-release


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow located in `.github/workflows/release.yml`.

The workflow automates the build, packaging, and release process for the `jcrud` C++ project using CMake.

Key features:
- Triggers on push to the `main` branch (for paths `src/**`, `thirdparty/**`, `CMakeLists.txt`) and on `workflow_dispatch`.
- Defines two main jobs: `build_and_package` and `create_release`.
- `build_and_package` job:
    - Checks out the code.
    - Installs dependencies (Boost, fmt, SQLite3, Crypto++).
    - Configures CMake for a Release build.
    - Builds the project.
    - Packages the `jcrud` executable into a .tar.gz archive.
    - Uploads the archive as a workflow artifact.
- `create_release` job:
    - Depends on the successful completion of `build_and_package`.
    - Runs only on pushes to the `main` branch.
    - Downloads the build artifact.
    - Generates a unique release tag (e.g., `release-YYYYMMDD-RUN_NUMBER`).
    - Creates a GitHub Release with the generated tag, including the build artifact.

This workflow will help ensure that every merge to main that changes relevant source files will result in a build and a corresponding release with the compiled application.